### PR TITLE
Fix Nginx configuration in Terraform setup

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,7 +135,7 @@ echo "${var.cloudflare_key}" > /etc/nginx/ssl/cloudflare.key
 chmod 600 /etc/nginx/ssl/cloudflare.key
 
 # Configure Nginx
-cat > /etc/nginx/sites-available/staging << 'EOL'
+cat > /etc/nginx/sites-available/staging << EOL
 # Rate limiting zones
 limit_req_zone $binary_remote_addr zone=login_limit:10m rate=1r/s;
 limit_req_zone $binary_remote_addr zone=general_limit:10m rate=10r/s;
@@ -169,7 +169,13 @@ server {
     location / {
         limit_req zone=general_limit burst=20;
         
-        if ($http_cookie !~ "auth=${base64encode("${var.staging_username}:${var.staging_password}")}") {
+        # Skip auth check for login page
+        if (\$request_uri = /login.html) {
+            break;
+        }
+        
+        # Check for auth cookie and redirect if not present
+        if (\$http_cookie !~ "auth=${base64encode("${var.staging_username}:${var.staging_password}")}") {
             return 302 /login.html;
         }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -137,8 +137,8 @@ chmod 600 /etc/nginx/ssl/cloudflare.key
 # Configure Nginx
 cat > /etc/nginx/sites-available/staging << EOL
 # Rate limiting zones
-limit_req_zone $binary_remote_addr zone=login_limit:10m rate=1r/s;
-limit_req_zone $binary_remote_addr zone=general_limit:10m rate=10r/s;
+limit_req_zone \$binary_remote_addr zone=login_limit:10m rate=1r/s;
+limit_req_zone \$binary_remote_addr zone=general_limit:10m rate=10r/s;
 
 # Staging server (with HTML form auth)
 server {
@@ -204,7 +204,7 @@ server {
 server {
     listen 80;
     server_name kerryai.app staging.kerryai.app;
-    return 301 https://$host$request_uri;
+    return 301 https://\$host\$request_uri;
 }
 EOL
 


### PR DESCRIPTION
- Fixed redirect loop issues by properly handling login.html path
- Corrected heredoc syntax by removing quotes from EOL delimiter to allow Terraform interpolation
- Added proper escaping for all Nginx variables:
  - \$binary_remote_addr in limit_req_zone directives
  - \$request_uri and \$http_cookie in auth checks
  - \$host and \$request_uri in HTTP to HTTPS redirect

These changes ensure proper variable interpolation between Terraform and Nginx configuration, and fix the authentication redirect loop that was preventing access to the staging site.